### PR TITLE
Handle crashes better.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ if [ "${LOADGAME_CHECK}" != "x" ]; then
       exec /app/bin/openttd -D -x -d "${DEBUG}"
       ;;
     'last-autosave')
-      savegame_target="${savepath}/autosave/$(ls -rt ${savepath}/autosave/ | tail -n1)"
+      savegame_target="${savepath}/autosave/$(ls -1rt ${savepath}/autosave/ | tail -n1)"
 
       if [ -r "${savegame_target}" ]; then
         echo "Loading from autosave - ${savegame_target}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # This script is based fairly heavily off bateau84/openttd's. Thanks, man!
 savepath="/config/save"
-LOADGAME_CHECK="${loadgame:-}x"
+LOADGAME_CHECK="${loadgame:=autosave/exit.sav}x"
 
 if [ ! -f /config/openttd.cfg ]; then
   # we start the server then kill it quickly to write a config file

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,58 +5,58 @@ savepath="/config/save"
 LOADGAME_CHECK="${loadgame}x"
 
 if [ ! -f /config/openttd.cfg ]; then
-        # we start the server then kill it quickly to write a config file
-        # yes this is a horrific hack but whatever
-        echo "No config file found: generating one"
-        timeout -t 3 /app/bin/openttd -D > /dev/null 2>&1
+  # we start the server then kill it quickly to write a config file
+  # yes this is a horrific hack but whatever
+  echo "No config file found: generating one"
+  timeout -t 3 /app/bin/openttd -D > /dev/null 2>&1
 fi
 
 if [ ${LOADGAME_CHECK} != "x" ]; then
-        case ${loadgame} in
-                'false')
-                	echo "Creating a new game."
-                    exec /app/bin/openttd -D -x -d ${DEBUG}
-                    exit 0
-                ;;
-                'last-autosave')
-            		savegame_target=${savepath}/autosave/`ls -rt ${savepath}/autosave/ | tail -n1`
+  case ${loadgame} in
+    'false')
+      echo "Creating a new game."
+      exec /app/bin/openttd -D -x -d ${DEBUG}
+      exit 0
+      ;;
+    'last-autosave')
+      savegame_target=${savepath}/autosave/`ls -rt ${savepath}/autosave/ | tail -n1`
 
-            		if [ -r ${savegame_target} ]; then
-                    	echo "Loading from autosave - ${savegame_target}"
-                        exec /app/bin/openttd -D -g ${savegame_target} -x -d ${DEBUG}
-                        exit 0
-            		else
-                		echo "${savegame_target} not found..."
-                		exit 1
-            		fi
-                ;;
-                'exit')
-            		savegame_target="${savepath}/autosave/exit.sav"
+      if [ -r ${savegame_target} ]; then
+        echo "Loading from autosave - ${savegame_target}"
+        exec /app/bin/openttd -D -g ${savegame_target} -x -d ${DEBUG}
+        exit 0
+      else
+        echo "${savegame_target} not found..."
+        exit 1
+      fi
+      ;;
+    'exit')
+      savegame_target="${savepath}/autosave/exit.sav"
 
-            		if [ -r ${savegame_target} ]; then
-                    	echo "Loading from exit save"
-                        exec /app/bin/openttd -D -g ${savegame_target} -x -d ${DEBUG}
-                        exit 0
-            		else
-                		echo "${savegame_target} not found - Creating a new game."
-                		exec /app/bin/openttd -D -x -d ${DEBUG}
-                    	exit 0
-            		fi
-                ;;
-                *)
-                	savegame_target="${savepath}/${loadgame}"
-                    if [ -f ${savegame_target} ]; then
-                            echo "Loading ${savegame_target}"
-                            exec /app/bin/openttd -D -g ${savegame_target} -x -d ${DEBUG}
-                            exit 0
-                    else
-                            echo "${savegame_target} not found..."
-                            exit 1
-                    fi
-                ;;
-        esac
+      if [ -r ${savegame_target} ]; then
+        echo "Loading from exit save"
+        exec /app/bin/openttd -D -g ${savegame_target} -x -d ${DEBUG}
+        exit 0
+      else
+        echo "${savegame_target} not found - Creating a new game."
+        exec /app/bin/openttd -D -x -d ${DEBUG}
+        exit 0
+      fi
+      ;;
+    *)
+      savegame_target="${savepath}/${loadgame}"
+      if [ -f ${savegame_target} ]; then
+        echo "Loading ${savegame_target}"
+        exec /app/bin/openttd -D -g ${savegame_target} -x -d ${DEBUG}
+        exit 0
+      else
+        echo "${savegame_target} not found..."
+        exit 1
+      fi
+      ;;
+  esac
 else
-		echo "loadgame not set - Creating a new game."
-    	exec /app/bin/openttd -D -x -d ${DEBUG}
-	    exit 0
+  echo "loadgame not set - Creating a new game."
+  exec /app/bin/openttd -D -x -d ${DEBUG}
+  exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # This script is based fairly heavily off bateau84/openttd's. Thanks, man!
 savepath="/config/save"
-LOADGAME_CHECK="${loadgame}x"
+LOADGAME_CHECK="${loadgame:-}x"
 
 if [ ! -f /config/openttd.cfg ]; then
   # we start the server then kill it quickly to write a config file
@@ -11,19 +11,19 @@ if [ ! -f /config/openttd.cfg ]; then
   timeout -t 3 /app/bin/openttd -D > /dev/null 2>&1
 fi
 
-if [ ${LOADGAME_CHECK} != "x" ]; then
+if [ "${LOADGAME_CHECK}" != "x" ]; then
   case ${loadgame} in
     'false')
       echo "Creating a new game."
-      exec /app/bin/openttd -D -x -d ${DEBUG}
+      exec /app/bin/openttd -D -x -d "${DEBUG}"
       exit 0
       ;;
     'last-autosave')
-      savegame_target=${savepath}/autosave/`ls -rt ${savepath}/autosave/ | tail -n1`
+      savegame_target="${savepath}/autosave/$(ls -rt ${savepath}/autosave/ | tail -n1)"
 
-      if [ -r ${savegame_target} ]; then
+      if [ -r "${savegame_target}" ]; then
         echo "Loading from autosave - ${savegame_target}"
-        exec /app/bin/openttd -D -g ${savegame_target} -x -d ${DEBUG}
+        exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
         exit 0
       else
         echo "${savegame_target} not found..."
@@ -33,21 +33,21 @@ if [ ${LOADGAME_CHECK} != "x" ]; then
     'exit')
       savegame_target="${savepath}/autosave/exit.sav"
 
-      if [ -r ${savegame_target} ]; then
+      if [ -r "${savegame_target}" ]; then
         echo "Loading from exit save"
-        exec /app/bin/openttd -D -g ${savegame_target} -x -d ${DEBUG}
+        exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
         exit 0
       else
         echo "${savegame_target} not found - Creating a new game."
-        exec /app/bin/openttd -D -x -d ${DEBUG}
+        exec /app/bin/openttd -D -x -d "${DEBUG}"
         exit 0
       fi
       ;;
     *)
       savegame_target="${savepath}/${loadgame}"
-      if [ -f ${savegame_target} ]; then
+      if [ -f "${savegame_target}" ]; then
         echo "Loading ${savegame_target}"
-        exec /app/bin/openttd -D -g ${savegame_target} -x -d ${DEBUG}
+        exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
         exit 0
       else
         echo "${savegame_target} not found..."
@@ -57,6 +57,6 @@ if [ ${LOADGAME_CHECK} != "x" ]; then
   esac
 else
   echo "loadgame not set - Creating a new game."
-  exec /app/bin/openttd -D -x -d ${DEBUG}
+  exec /app/bin/openttd -D -x -d "${DEBUG}"
   exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,6 @@ if [ "${LOADGAME_CHECK}" != "x" ]; then
     'false')
       echo "Creating a new game."
       exec /app/bin/openttd -D -x -d "${DEBUG}"
-      exit 0
       ;;
     'last-autosave')
       savegame_target="${savepath}/autosave/$(ls -rt ${savepath}/autosave/ | tail -n1)"
@@ -24,7 +23,6 @@ if [ "${LOADGAME_CHECK}" != "x" ]; then
       if [ -r "${savegame_target}" ]; then
         echo "Loading from autosave - ${savegame_target}"
         exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
-        exit 0
       else
         echo "${savegame_target} not found..."
         exit 1
@@ -36,11 +34,9 @@ if [ "${LOADGAME_CHECK}" != "x" ]; then
       if [ -r "${savegame_target}" ]; then
         echo "Loading from exit save"
         exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
-        exit 0
       else
         echo "${savegame_target} not found - Creating a new game."
         exec /app/bin/openttd -D -x -d "${DEBUG}"
-        exit 0
       fi
       ;;
     *)
@@ -48,7 +44,6 @@ if [ "${LOADGAME_CHECK}" != "x" ]; then
       if [ -f "${savegame_target}" ]; then
         echo "Loading ${savegame_target}"
         exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
-        exit 0
       else
         echo "${savegame_target} not found..."
         exit 1
@@ -58,5 +53,4 @@ if [ "${LOADGAME_CHECK}" != "x" ]; then
 else
   echo "loadgame not set - Creating a new game."
   exec /app/bin/openttd -D -x -d "${DEBUG}"
-  exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
-# This script is based fairly heavily off bateau84/openttd's. Thanks, man!
+# This script is based off bateau84/openttd's. Thanks, man!
 savepath="/config/save"
-LOADGAME_CHECK="${loadgame:=autosave/exit.sav}x"
 
 if [ ! -f /config/openttd.cfg ]; then
   # we start the server then kill it quickly to write a config file
@@ -11,46 +10,31 @@ if [ ! -f /config/openttd.cfg ]; then
   timeout -t 3 /app/bin/openttd -D > /dev/null 2>&1
 fi
 
-if [ "${LOADGAME_CHECK}" != "x" ]; then
-  case ${loadgame} in
-    'false')
+autosave_target=""
+savegame_target="${savepath}/${loadgame:=exit}"
+case ${loadgame} in
+  'exit')
+    savegame_target="${savepath}/autosave/exit.sav"
+    ;&
+  'last-autosave')
+    autosave_target="${savepath}/autosave/$(ls -1rt ${savepath}/autosave/ | tail -n1)"
+    # IFF the the exit savegame is older than the autosave, we're recovering from a crash.
+    # Also handles the not-found case - A nonexistent file is older than an existing file.
+    if [[ "${savegame_target}" -ot "${autosave_target}" ]]; then
+      savegame_target="${autosave_target}"
+    fi
+    ;;&
+  *)
+    if [ -f "${savegame_target}" ]; then
+      echo "Loading ${savegame_target}"
+      exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
+    else
+      if [[ ${loadgame} != "false" ]]; then
+        echo "${savegame_target} not found..."
+      fi
       echo "Creating a new game."
       exec /app/bin/openttd -D -x -d "${DEBUG}"
-      ;;
-    'last-autosave')
-      savegame_target="${savepath}/autosave/$(ls -1rt ${savepath}/autosave/ | tail -n1)"
-
-      if [ -r "${savegame_target}" ]; then
-        echo "Loading from autosave - ${savegame_target}"
-        exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
-      else
-        echo "${savegame_target} not found..."
-        exit 1
-      fi
-      ;;
-    'exit')
-      savegame_target="${savepath}/autosave/exit.sav"
-
-      if [ -r "${savegame_target}" ]; then
-        echo "Loading from exit save"
-        exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
-      else
-        echo "${savegame_target} not found - Creating a new game."
-        exec /app/bin/openttd -D -x -d "${DEBUG}"
-      fi
-      ;;
-    *)
-      savegame_target="${savepath}/${loadgame}"
-      if [ -f "${savegame_target}" ]; then
-        echo "Loading ${savegame_target}"
-        exec /app/bin/openttd -D -g "${savegame_target}" -x -d "${DEBUG}"
-      else
-        echo "${savegame_target} not found..."
-        exit 1
-      fi
-      ;;
-  esac
-else
-  echo "loadgame not set - Creating a new game."
-  exec /app/bin/openttd -D -x -d "${DEBUG}"
-fi
+      exit 1
+    fi
+    ;;
+esac

--- a/k8s/openttd.yaml
+++ b/k8s/openttd.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: openttd-server
+  namespace: default
+spec:
+  podManagementPolicy: OrderedReady
+  selector:
+    matchLabels:
+      app: openttd
+  serviceName: openttd
+  template:
+    metadata:
+      labels:
+        app: openttd
+      name: openttd
+    spec:
+      containers:
+      - args: []
+        env: []
+        image: gauntletwizard/misc:openttd
+        name: openttd
+        ports:
+        - containerPort: 3979
+          name: openttd
+        volumeMounts:
+        - mountPath: /config
+          name: openttd-data
+      securityContext:
+        runAsGroup: 911
+        runAsUser: 911
+      serviceAccountName: openttd
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: openttd-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: openttd-svc
+  name: openttd-svc
+  namespace: default
+spec:
+  ports:
+  - name: game
+    # These two need to be manually set, because otherwise they'll get non-matching ports
+    nodePort: 32573
+    port: 3979
+    protocol: UDP
+    targetPort: 3979
+  - name: gametcp
+    nodePort: 32573
+    port: 3979
+    protocol: TCP
+    targetPort: 3979
+  selector:
+    app: openttd
+  type: NodePort


### PR DESCRIPTION
Complete rewrite to duplicate less, and handle container failure better. Exit strategy should use last-autosave if last-autosave is newer than exit savefile (Which indicates that the server shutdown uncleanly). Otherwise, it should behave identically, which a bunch less duplication.

I started off with some less-invasive fixes, if you'd prefer :)