### PR TITLE
PUID & GUID to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM debian:stable-slim AS ottd_build
 ARG OPENTTD_VERSION="1.10.1"
 ARG OPENGFX_VERSION="0.6.0"
 
+# Setup user and group parameters
+ENV PUID="1000"
+ENV GUID="1000"
+
 # Get things ready
 RUN mkdir -p /config \
     && mkdir /tmp/src
@@ -87,5 +91,6 @@ EXPOSE 3979/udp
 EXPOSE 3977/tcp
 
 # Finally, let's run OpenTTD!
-USER openttd
+USER ${UID}:${GID}
+
 CMD /usr/local/bin/entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ EXPOSE 3979/udp
 EXPOSE 3977/tcp
 
 # Finally, let's run OpenTTD!
-USER ${UID}:${GID}
+USER ${PUID}:${GUID}
 
 CMD /usr/local/bin/entrypoint
+ 


### PR DESCRIPTION
I think this corrects the issue I raised. 

I am unclear if there is any undesired effects of removing the current user openttd, however in local testing all seemed to work as expected.

In the interest of full disclosure I can't fully validate this container config on my Synology as I am building it on an ARM M1 Mac, which fails to run on the Synology. Running locally appears to have the desired effect. 

Thanks for your responsiveness on the issue!