### PR TITLE
Fix #14: allow for UID/GID specification via PUID/PGID env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,9 @@ RUN mkdir -p /config \
     zlib1g \
     liblzma5 \
     liblzo2-2 \
-    nano
+    nano \
+    gosu \
+    && gosu nobody true
 
 WORKDIR /config
 
@@ -69,6 +71,7 @@ WORKDIR /config
 COPY --from=ottd_build /app /app
 
 # Add the entrypoint
+ADD startgame.sh /usr/local/bin/startgame
 ADD entrypoint.sh /usr/local/bin/entrypoint
 
 # Expose the volume
@@ -89,5 +92,4 @@ ENV XDG_DATA_HOME=/config
 ENV PATH="$PATH:/app"
 
 # Finally, let's run OpenTTD!
-USER openttd
 CMD [ "/usr/local/bin/entrypoint" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,70 +1,31 @@
 #!/bin/sh
 
-# This script is based fairly heavily off bateau84/openttd's. Thanks, man!
+# This is the script that will run at the end
+set -- /usr/local/bin/startgame "$@"
 
-SAVEPATH="/config/save"
-LOADGAME_CHECK="${loadgame}x"
-EXTRA_FLAGS="-c /config/openttd.cfg"
+# Change openttd user and group ids to what was specified
+PUID=${PUID:-911}
+PGID=${PGID:-1000}
+groupmod -o -g "$PGID" openttd
+usermod -o -u "$PUID" openttd
 
-# Required to force config to save to /config
-if [ -f /config/.config/openttd.cfg ]; then
-        export XDG_DATA_HOME=''
-        SAVEPATH="/config/.config/save"
-        EXTRA_FLAGS="-c /config/.config/openttd.cfg"
-        echo "WARN: Using legacy configuration directory /config/.config/ - it is recommended to migrate to all data inside /config/* when possible."
-elif [ ! -f /config/openttd.cfg ]; then
-        # we start the server then kill it quickly to write a config file
-        # yes this is a horrific hack but whatever
-        echo "INFO: No config file found: generating one"
-        timeout 3 /app/openttd -D ${EXTRA_FLAGS} > /dev/null 2>&1
-fi
+# Take ownership of /config and /app
+chown -R openttd:openttd /config
+chown -R openttd:openttd /app
 
-if [ "${LOADGAME_CHECK}" != "x" ]; then
-        case ${loadgame} in
-                'false')
-                        echo "INFO: Creating a new game."
-                        exec /app/openttd -D ${EXTRA_FLAGS} -x  -d ${DEBUG}
-                        exit 0
-                ;;
-                'last-autosave')
-            		SAVEGAME_TARGET=`ls -rt ${SAVEPATH}/autosave/*.sav | tail -n1`
+echo "
 
-            		if [ -r "${SAVEGAME_TARGET}" ]; then
-                                echo "INFO: Loading from latest autosave - ${SAVEGAME_TARGET}"
-                                exec /app/openttd -D ${EXTRA_FLAGS} -g "${SAVEGAME_TARGET}" -x -d ${DEBUG}
-                                exit 0
-            		else
-                		echo "FATAL: ${SAVEGAME_TARGET} not found"
-                		exit 1
-            		fi
-                ;;
-                'exit')
-            		SAVEGAME_TARGET="${SAVEPATH}/autosave/exit.sav"
+User UID:    $(id -u openttd)
+User GID:    $(id -g openttd)
 
-            		if [ -r "${SAVEGAME_TARGET}" ]; then
-                                echo "INFO: Loading from exit save"
-                                exec /app/openttd -D ${EXTRA_FLAGS} -g "${SAVEGAME_TARGET}" -x -d ${DEBUG}
-                                exit 0
-            		else
-                		echo "${SAVEGAME_TARGET} not found - Creating a new game."
-                		exec /app/openttd -D ${EXTRA_FLAGS} -x -d ${DEBUG}
-                    	        exit 0
-            		fi
-                ;;
-                *)
-                        SAVEGAME_TARGET="${SAVEPATH}/${loadgame}"
-                        if [ -r "${SAVEGAME_TARGET}" ]; then
-                                echo "INFO: Loading ${SAVEGAME_TARGET}"
-                                exec /app/openttd -D ${EXTRA_FLAGS} -g "${SAVEGAME_TARGET}" -x -d ${DEBUG}
-                                exit 0
-                        else
-                                echo "FATAL: ${SAVEGAME_TARGET} not found"
-                                exit 1
-                        fi
-                ;;
-        esac
-else
-        echo "INFO: loadgame not set - Creating a new game."
-    	exec /app/openttd -D ${EXTRA_FLAGS} -x -d ${DEBUG}
-        exit 0
-fi
+───────────────────────────────────────
+
+"
+
+# Drop from root to the openttd user
+set -- gosu openttd "$@"
+
+# Run original entrypoint
+exec "$@"
+
+

--- a/startgame.sh
+++ b/startgame.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+# This script is based fairly heavily off bateau84/openttd's. Thanks, man!
+
+SAVEPATH="/config/save"
+LOADGAME_CHECK="${loadgame}x"
+EXTRA_FLAGS="-c /config/openttd.cfg"
+
+# Required to force config to save to /config
+if [ -f /config/.config/openttd.cfg ]; then
+        export XDG_DATA_HOME=''
+        SAVEPATH="/config/.config/save"
+        EXTRA_FLAGS="-c /config/.config/openttd.cfg"
+        echo "WARN: Using legacy configuration directory /config/.config/ - it is recommended to migrate to all data inside /config/* when possible."
+elif [ ! -f /config/openttd.cfg ]; then
+        # we start the server then kill it quickly to write a config file
+        # yes this is a horrific hack but whatever
+        echo "INFO: No config file found: generating one"
+        timeout 3 /app/openttd -D ${EXTRA_FLAGS} > /dev/null 2>&1
+fi
+
+if [ "${LOADGAME_CHECK}" != "x" ]; then
+        case ${loadgame} in
+                'false')
+                        echo "INFO: Creating a new game."
+                        exec /app/openttd -D ${EXTRA_FLAGS} -x  -d ${DEBUG}
+                        exit 0
+                ;;
+                'last-autosave')
+            		SAVEGAME_TARGET=`ls -rt ${SAVEPATH}/autosave/*.sav | tail -n1`
+
+            		if [ -r "${SAVEGAME_TARGET}" ]; then
+                                echo "INFO: Loading from latest autosave - ${SAVEGAME_TARGET}"
+                                exec /app/openttd -D ${EXTRA_FLAGS} -g "${SAVEGAME_TARGET}" -x -d ${DEBUG}
+                                exit 0
+            		else
+                		echo "FATAL: ${SAVEGAME_TARGET} not found"
+                		exit 1
+            		fi
+                ;;
+                'exit')
+            		SAVEGAME_TARGET="${SAVEPATH}/autosave/exit.sav"
+
+            		if [ -r "${SAVEGAME_TARGET}" ]; then
+                                echo "INFO: Loading from exit save"
+                                exec /app/openttd -D ${EXTRA_FLAGS} -g "${SAVEGAME_TARGET}" -x -d ${DEBUG}
+                                exit 0
+            		else
+                		echo "${SAVEGAME_TARGET} not found - Creating a new game."
+                		exec /app/openttd -D ${EXTRA_FLAGS} -x -d ${DEBUG}
+                    	        exit 0
+            		fi
+                ;;
+                *)
+                        SAVEGAME_TARGET="${SAVEPATH}/${loadgame}"
+                        if [ -r "${SAVEGAME_TARGET}" ]; then
+                                echo "INFO: Loading ${SAVEGAME_TARGET}"
+                                exec /app/openttd -D ${EXTRA_FLAGS} -g "${SAVEGAME_TARGET}" -x -d ${DEBUG}
+                                exit 0
+                        else
+                                echo "FATAL: ${SAVEGAME_TARGET} not found"
+                                exit 1
+                        fi
+                ;;
+        esac
+else
+        echo "INFO: loadgame not set - Creating a new game."
+    	exec /app/openttd -D ${EXTRA_FLAGS} -x -d ${DEBUG}
+        exit 0
+fi


### PR DESCRIPTION
Hi there!

I made it so you can specify PUID/PGID when starting this container, fixing #14.

TLDR; Add the openttd user as normal, but run a new entrypoint as root which changes the uid/gid on "openttd" to the specified ones and then drops privileges to that user and runs the original entrypoint

I took some inspiration from how LinuxServers do it [1] , and also this Dockerfile/entrypoint where gosu was used https://github.com/sudo-bmitch/jenkins-docker/tree/main

Using gosu seems to be common practice [3] 

[1] https://github.com/linuxserver/docker-baseimage-ubuntu/blob/focal/root/etc/s6-overlay/s6-rc.d/init-adduser/run
[2] (https://github.com/tianon/gosu?tab=readme-ov-file#gosu
[3] https://denibertovic.com/posts/handling-permissions-with-docker-volumes/